### PR TITLE
hotfix(chrony): Add chrony_filename default filename chrony.config

### DIFF
--- a/roles/chrony/tasks/debian.yml
+++ b/roles/chrony/tasks/debian.yml
@@ -4,4 +4,5 @@
     chrony_service: chronyd
     chrony_package: chrony
     chrony_dir: /etc/chrony/
+    chrony_filename: "{{ (chrony_filename == 'DEFAULT') | ternary ('chrony.conf', chrony_filename) }}"
   when: chrony_dir == 'DEFAULT' and ansible_pkg_mgr == 'apt'

--- a/roles/chrony/tasks/redhat.yml
+++ b/roles/chrony/tasks/redhat.yml
@@ -4,4 +4,5 @@
     chrony_service: chronyd
     chrony_package: chrony
     chrony_dir: /etc/
+    chrony_filename: "{{ (chrony_filename == 'DEFAULT') | ternary ('chrony.conf', chrony_filename) }}"
   when: chrony_dir == 'DEFAULT' and ansible_pkg_mgr == 'yum'


### PR DESCRIPTION
- Chrony config name never get a default value chrony.conf
-- After this change, the chrony_filename will get the default value if the use not set one. 